### PR TITLE
Typings fail with "noImplicitAny" setting

### DIFF
--- a/bottleneck.d.ts
+++ b/bottleneck.d.ts
@@ -229,16 +229,16 @@ declare module "bottleneck" {
         chain(limiter?: Bottleneck): Bottleneck;
 
         wrap<R>(fn: () => PromiseLike<R>): () => Promise<R>;
-        wrap<R, A1>(fn: (arg1: A1) => PromiseLike<R>): (A1) => Promise<R>;
-        wrap<R, A1, A2>(fn: (arg1: A1, arg2: A2) => PromiseLike<R>): (A1, A2) => Promise<R>;
-        wrap<R, A1, A2, A3>(fn: (arg1: A1, arg2: A2, arg3: A3) => PromiseLike<R>): (A1, A2, A3) => Promise<R>;
-        wrap<R, A1, A2, A3, A4>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => PromiseLike<R>): (A1, A2, A3, A4) => Promise<R>;
-        wrap<R, A1, A2, A3, A4, A5>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => PromiseLike<R>): (A1, A2, A3, A4, A5) => Promise<R>;
-        wrap<R, A1, A2, A3, A4, A5, A6>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6) => PromiseLike<R>): (A1, A2, A3, A4, A5, A6) => Promise<R>;
-        wrap<R, A1, A2, A3, A4, A5, A6, A7>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7) => PromiseLike<R>): (A1, A2, A3, A4, A5, A6, A7) => Promise<R>;
-        wrap<R, A1, A2, A3, A4, A5, A6, A7, A8>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8) => PromiseLike<R>): (A1, A2, A3, A4, A5, A6, A7, A8) => Promise<R>;
-        wrap<R, A1, A2, A3, A4, A5, A6, A7, A8, A9>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8, arg9: A9) => PromiseLike<R>): (A1, A2, A3, A4, A5, A6, A7, A8, A9) => Promise<R>;
-        wrap<R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8, arg9: A9, arg10: A10) => PromiseLike<R>): (A1, A2, A3, A4, A5, A6, A7, A8, A9, A10) => Promise<R>;
+        wrap<R, A1>(fn: (arg1: A1) => PromiseLike<R>): (arg1: A1) => Promise<R>;
+        wrap<R, A1, A2>(fn: (arg1: A1, arg2: A2) => PromiseLike<R>): (arg1: A1, arg2: A2) => Promise<R>;
+        wrap<R, A1, A2, A3>(fn: (arg1: A1, arg2: A2, arg3: A3) => PromiseLike<R>): (arg1: A1, arg2: A2, arg3: A3) => Promise<R>;
+        wrap<R, A1, A2, A3, A4>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => PromiseLike<R>): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Promise<R>;
+        wrap<R, A1, A2, A3, A4, A5>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => PromiseLike<R>): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Promise<R>;
+        wrap<R, A1, A2, A3, A4, A5, A6>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6) => PromiseLike<R>): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6) => Promise<R>;
+        wrap<R, A1, A2, A3, A4, A5, A6, A7>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7) => PromiseLike<R>): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7) => Promise<R>;
+        wrap<R, A1, A2, A3, A4, A5, A6, A7, A8>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8) => PromiseLike<R>): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8) => Promise<R>;
+        wrap<R, A1, A2, A3, A4, A5, A6, A7, A8, A9>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8, arg9: A9) => PromiseLike<R>): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8, arg9: A9) => Promise<R>;
+        wrap<R, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10>(fn: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8, arg9: A9, arg10: A10) => PromiseLike<R>): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, arg6: A6, arg7: A7, arg8: A8, arg9: A9, arg10: A10) => Promise<R>;
 
         submit<R>(fn: (callback: Bottleneck.Callback<R>) => void, callback: Bottleneck.Callback<R>): void;
         submit<R, A1>(fn: (arg1: A1, callback: Bottleneck.Callback<R>) => void, arg1: A1, callback: Bottleneck.Callback<R>): void;

--- a/bottleneck.d.ts.ejs
+++ b/bottleneck.d.ts.ejs
@@ -229,7 +229,7 @@ declare module "bottleneck" {
         chain(limiter?: Bottleneck): Bottleneck;
 
         <%_ for (var count of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) { _%>
-        wrap<R<%_ for (var idx = 1; idx <= count; idx++) { _%>, A<%= idx %><%_ } _%>>(fn: (<%= Array.apply(null, Array(count)).map((e, i) => i+1).map(i => `arg${i}: A${i}`).join(", ") %>) => PromiseLike<R>): (<%_ for (var idx = 1; idx <= count; idx++) { _%><% if (idx > 1) { %>, <% } %>A<%= idx %><% } _%>) => Promise<R>;
+        wrap<R<%_ for (var idx = 1; idx <= count; idx++) { _%>, A<%= idx %><%_ } _%>>(fn: (<%= Array.apply(null, Array(count)).map((e, i) => i+1).map(i => `arg${i}: A${i}`).join(", ") %>) => PromiseLike<R>): (<%_ for (var idx = 1; idx <= count; idx++) { _%><% if (idx > 1) { %>, <% } %>arg<%= idx %>: A<%= idx %><% } _%>) => Promise<R>;
         <%_ } _%>
 
         <%_ for (var count of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) { _%>


### PR DESCRIPTION
This PR corrects the Typescript typings. These cause several errors when compiling with the [`noImplicitAny` option](https://www.typescriptlang.org/docs/handbook/compiler-options.html):

```
node_modules/bottleneck/bottleneck.d.ts(232,57): error TS7006: Parameter 'A1' implicitly has an 'any' type.
node_modules/bottleneck/bottleneck.d.ts(233,71): error TS7006: Parameter 'A1' implicitly has an 'any' type.
node_modules/bottleneck/bottleneck.d.ts(233,75): error TS7006: Parameter 'A2' implicitly has an 'any' type.
node_modules/bottleneck/bottleneck.d.ts(234,85): error TS7006: Parameter 'A1' implicitly has an 'any' type.
node_modules/bottleneck/bottleneck.d.ts(234,89): error TS7006: Parameter 'A2' implicitly has an 'any' type.
[...49 similar messages omitted for brevity...]
```