### PR TITLE
Force wrap() to always return a promise

### DIFF
--- a/es5.js
+++ b/es5.js
@@ -4612,11 +4612,22 @@
 	        schedule = this.schedule;
 
 	        wrapped = function wrapped() {
+	          var _this9 = this;
+
 	          for (var _len8 = arguments.length, args = new Array(_len8), _key8 = 0; _key8 < _len8; _key8++) {
 	            args[_key8] = arguments[_key8];
 	          }
 
-	          return schedule.apply(void 0, [fn.bind(this)].concat(args));
+	          return schedule(function () {
+	            var e;
+
+	            try {
+	              return Promise.resolve(fn.apply(_this9, args));
+	            } catch (error1) {
+	              e = error1;
+	              return Promise.reject(e);
+	            }
+	          });
 	        };
 
 	        wrapped.withOptions = function (options) {

--- a/lib/Bottleneck.js
+++ b/lib/Bottleneck.js
@@ -592,7 +592,16 @@ Bottleneck = function () {
       schedule = this.schedule;
 
       wrapped = function wrapped(...args) {
-        return schedule(fn.bind(this), ...args);
+        return schedule(() => {
+          var e;
+
+          try {
+            return Promise.resolve(fn.apply(this, args));
+          } catch (error1) {
+            e = error1;
+            return Promise.reject(e);
+          }
+        });
       };
 
       wrapped.withOptions = (options, ...args) => {

--- a/light.js
+++ b/light.js
@@ -1283,7 +1283,15 @@
 	      var schedule, wrapped;
 	      schedule = this.schedule;
 	      wrapped = function(...args) {
-	        return schedule(fn.bind(this), ...args);
+	        return schedule(() => {
+	          var e;
+	          try {
+	            return Promise.resolve(fn.apply(this, args));
+	          } catch (error1) {
+	            e = error1;
+	            return Promise.reject(e);
+	          }
+	        });
 	      };
 	      wrapped.withOptions = (options, ...args) => {
 	        return schedule(options, fn, ...args);

--- a/src/Bottleneck.coffee
+++ b/src/Bottleneck.coffee
@@ -295,7 +295,11 @@ class Bottleneck
 
   wrap: (fn) ->
     schedule = @schedule
-    wrapped = (args...) -> schedule fn.bind(@), args...
+    wrapped = (args...) -> schedule () =>
+      try
+        Promise.resolve fn.apply(@, args)
+      catch e
+        Promise.reject e
     wrapped.withOptions = (options, args...) => schedule options, fn, args...
     wrapped
 

--- a/test/promises.js
+++ b/test/promises.js
@@ -98,6 +98,26 @@ describe('Promises', function () {
       })
     })
 
+    it('Should automatically wrap a returned value in a resolved promise', function () {
+      c = makeTest({maxConcurrent: 1, minTime: 100})
+
+      fn = c.limiter.wrap(() => { return 7 });
+
+      return fn().then(result => {
+        assert(result === 7);
+      })
+    })
+
+    it('Should automatically wrap an exception in a rejected promise', function () {
+      c = makeTest({maxConcurrent: 1, minTime: 100})
+
+      fn = c.limiter.wrap(() => { throw new Error('I will reject') });
+
+      return fn().then(() => assert(false)).catch(error => {
+        assert(error.message === 'I will reject');
+      })
+    })
+
     it('Should inherit the original target for wrapped methods', function () {
       c = makeTest({maxConcurrent: 1, minTime: 100})
 


### PR DESCRIPTION
### SUMMARY

Ensure that `wrap()` will always return a Promise, even if the original method does not.

### DETAILS

The documentation says that `wrap()` should be "passed a function that returns a promise".  If you want to avoid accidental exceptions breaking your promise chain, that means you should do something like this:

    const Promise = require('bluebird');

    limiter.wrap(Promise.method(() => {
        throw new Error('Oops, an accidental error in this method');
    }));

My suggestion would be that the library _either_ (A) intentionally rejects if the original function _doesn't_ return a Promise (that would notify the user to fix the issue), or (B) do a Promise wrapper for the user, so they don't have to worry about it.  My preference is (B), so that's what is in this PR; it just ensures that this does what you want:

    limiter.wrap(() => {
        throw new Error('I want to be a rejected promise');
    }));

### TESTS

- Passed once locally and failed once locally, on some (unrelated?) tests 🤞 
- I added a test both for "resolved" and "rejected" values (the resolved case worked correctly even before my changes, the extra test is only to document the desired behavior).
