### PR TITLE
Allow failed event handler to return Promise<void> or number

### DIFF
--- a/bottleneck.d.ts
+++ b/bottleneck.d.ts
@@ -491,7 +491,7 @@ declare module "bottleneck" {
         on(name: "queued",    fn: (info: Bottleneck.EventInfoQueued) => void): void;
         on(name: "scheduled", fn: (info: Bottleneck.EventInfo) => void): void;
         on(name: "executing", fn: (info: Bottleneck.EventInfoRetryable) => void): void;
-        on(name: "failed",    fn: (error: any, info: Bottleneck.EventInfoRetryable) => Promise<number> | void): void;
+        on(name: "failed",    fn: (error: any, info: Bottleneck.EventInfoRetryable) => Promise<number | void> | number | void): void;
         on(name: "retry",     fn: (message: string, info: Bottleneck.EventInfoRetryable) => void): void;
         on(name: "done",      fn: (info: Bottleneck.EventInfoRetryable) => void): void;
 
@@ -511,7 +511,7 @@ declare module "bottleneck" {
         once(name: "queued",    fn: (info: Bottleneck.EventInfoQueued) => void): void;
         once(name: "scheduled", fn: (info: Bottleneck.EventInfo) => void): void;
         once(name: "executing", fn: (info: Bottleneck.EventInfoRetryable) => void): void;
-        once(name: "failed",    fn: (error: any, info: Bottleneck.EventInfoRetryable) => Promise<number> | void): void;
+        once(name: "failed",    fn: (error: any, info: Bottleneck.EventInfoRetryable) => Promise<number | void> | number | void): void;
         once(name: "retry",     fn: (message: string, info: Bottleneck.EventInfoRetryable) => void): void;
         once(name: "done",      fn: (info: Bottleneck.EventInfoRetryable) => void): void;
 


### PR DESCRIPTION
The type for the `failed` event only allowed you to return a `Promise<number>` or `void`.  However, you might want to return a `number` synchronously, or return `void` asynchronously.  This change allows those other cases in the `failed` event handler.