### PR TITLE
Don't package unnecessary files in npm pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,12 @@
   "bugs": {
     "url": "https://github.com/SGrondin/bottleneck/issues"
   },
+  "files": [
+    "lib/*",
+    "*.js",
+    "*.ejs",
+    "*.ts"
+  ],
   "devDependencies": {
     "@babel/core": "^7.5.0",
     "@babel/preset-env": "^7.5.0",


### PR DESCRIPTION
### SUMMARY

I noticed that the bundle size for `bottleneck` is larger than I'd expect, since (by default) it is packing everything.  I took a stab at limiting this only to files that are necessary.

### DETAILS

- Pack `lib/*`, along with `*.(js|ejs|ts)`.  You might be able to restrict this even further, but at least this keeps the `src` and `test` folders out of the distributed package, which is the main goal.
