### PR TITLE
Fix minTime description text in tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var Bottleneck = require("bottleneck/es5");
 
 ### Step 1 of 3
 
-Most APIs have a rate limit. For example, to execute 3 requests per second:
+Most APIs have a rate limit. For example, to wait 333ms after launching a job before launching another one:
 ```js
 const limiter = new Bottleneck({
   minTime: 333


### PR DESCRIPTION
First time user here.
While reading the docs, I noticed that the description for step 1 is wrong:
We don't limit the number of requests per second, but instead introduce a waiting time first.
Minor thing, but got me confused for a second. 😉 Otherwise great lib! 