### PR TITLE
Add flush method to Batcher

### DIFF
--- a/bottleneck.d.ts
+++ b/bottleneck.d.ts
@@ -298,9 +298,14 @@ declare module "bottleneck" {
           * Add a request to the Batcher. Batches are flushed to the "batch" event.
           */
         add(data: any): Promise<void>;
+
+        /**
+         * Force a 'batch' event if there are any rows currently in the batch
+         */
+        flush(): void;
     }
 
-    class Group {
+        class Group {
         constructor(options?: Bottleneck.ConstructorOptions);
 
         id: string;

--- a/bottleneck_types.ejs
+++ b/bottleneck_types.ejs
@@ -297,6 +297,11 @@ namespace Bottleneck {
           * Add a request to the Batcher. Batches are flushed to the "batch" event.
           */
         add(data: any): Promise<void>;
+
+        /**
+         * Force a 'batch' event if there are any rows currently in the batch
+         */
+        flush(): void;
     }
 
     class Group {

--- a/src/Batcher.coffee
+++ b/src/Batcher.coffee
@@ -35,5 +35,9 @@ class Batcher
         @_flush()
       , @maxTime
     ret
+  
+  flush: ->
+    if @_arr.length
+      @_flush()
 
 module.exports = Batcher

--- a/src/Batcher.coffee
+++ b/src/Batcher.coffee
@@ -35,7 +35,7 @@ class Batcher
         @_flush()
       , @maxTime
     ret
-  
+
   flush: ->
     if @_arr.length
       @_flush()


### PR DESCRIPTION

The ability to trigger a manual flush of any remaining rows is needed when you reach the end of a data set and there will be no more rows coming.  Otherwise there's no simple way to process the final batch that is still in the batcher.

See https://github.com/SGrondin/bottleneck/issues/166
